### PR TITLE
Improved documentation. Added On/Off settings for plugin and email.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -17,6 +17,7 @@ class Plugin extends Base
     public function initialize()
     {
         $this->template->hook->attach('template:config:integrations', 'imap:integration');
+        $this->hook->on('template:layout:js', array('template' => 'plugins/Imap/Asset/integration.js'));
     }
 
     public function onStartup()
@@ -36,7 +37,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '0.0.1';
+        return '0.0.2';
     }
 
     public function getPluginHomepage()

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Testing
 You can send an email with the format _happykanboard+PROJECTIDENTIFIER@riseup.net_. The email subject will become the task title, and the email body that will become the task content.
 
 You can also send an email with this format in subject: _Finish Duke Nukem Forever 2 \<PROJECTIDENTIFIER\> please!_ The task title will be "Finish Duke Nukem Forever 2 please!", and details in the email body that will be the task content.
+
+If automatic confirmation emails are enabled, you should receive confirmation that the task was created. You can reply to the confirmation email to add comments to the task.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Kanboard IMAP Tasks
 =====================
 
 
-- Create tasks by mails fetched from IMAP
+- Create tasks by email fetched from IMAP
 
 Author
 ------
@@ -37,11 +37,11 @@ Configuration
 -------------
 
 Go to Kanboard -> Settings -> Integrations
-Go to Kanboard -> Project -> Menu -> Settings -> Edit project and add a Identifier
+Go to Kanboard -> Project -> Menu -> Settings -> Edit project and add an Identifier
 
 Testing
 -------
 
-You can send a email with this format happykanboard+PROJECTIDENTIFIER@riseup.net put a subject that will be the task title and details in the email body that will be the task content.
+You can send an email with the format _happykanboard+PROJECTIDENTIFIER@riseup.net_. The email subject will become the task title, and the email body that will become the task content.
 
-You can also send a email with this format in subject: Finish Duke Nukem Forever 2 \<PROJECTIDENTIFIER\> please! Finish Duke Nukem Forever 2 please! will be the title and details in the email body that will be the task content.
+You can also send an email with this format in subject: _Finish Duke Nukem Forever 2 \<PROJECTIDENTIFIER\> please!_ The task title will be "Finish Duke Nukem Forever 2 please!", and details in the email body that will be the task content.

--- a/Template/integration.php
+++ b/Template/integration.php
@@ -1,15 +1,18 @@
-<h3><img src="<?= $this->url->dir() ?>plugins/Imap/imap-icon.png"/>&nbsp;Imap</h3>
-<div class="listing">
+<h3><img src="<?= $this->url->dir() ?>plugins/Imap/imap-icon.png" alt=""/>&nbsp;Imap</h3>
+<div class="panel listing">
 
     <h3>IMAP Configuration</h3>
+	<?= $this->form->label(t('IMAP Enabled'), 'imap_enabled')  ?>
+	<?= $this->form->select('imap_enabled', array(0 => 'No', 1 => 'Yes'), $values) ?>
+
     <?= $this->form->label(t('IMAP Server'), 'imap_server') ?>
     <?= $this->form->text('imap_server', $values) ?>
 
     <?= $this->form->label(t('IMAP Server Port'), 'imap_server_port') ?>
     <?= $this->form->text('imap_server_port', $values) ?>
 
-    <?= $this->form->label(t('IMAP Server Requires SSL (0/1)'), 'imap_server_requires_ssl') ?>
-    <?= $this->form->text('imap_server_requires_ssl', $values) ?>
+	<?= $this->form->label(t('IMAP Server Requires Valid SSL'), 'imap_server_requires_ssl')  ?>
+	<?= $this->form->select('imap_server_requires_ssl', array(0 => 'No', 1 => 'Yes'), $values) ?>
 
     <?= $this->form->label(t('IMAP Username'), 'imap_username') ?>
     <?= $this->form->text('imap_username', $values) ?>
@@ -17,23 +20,29 @@
     <?= $this->form->label(t('IMAP Password'), 'imap_password') ?>
     <?= $this->form->password('imap_password', $values) ?>
 
-    <?= $this->form->label(t("Mail prefix (Default: Add a '+' to your username)"), 'imap_mail_prefix') ?>
-    <?= $this->form->text('imap_mail_prefix', $values) ?>
+    <?= $this->form->label(t("IMAP Mail Prefix (Default: Add a '+' to your username)"), 'imap_mail_prefix') ?>
+    <?= $this->form->text('imap_mail_prefix', $values, array(),
+        isset($values['imap_username']) ?
+            array('placeholder="'.htmlentities(preg_replace('/@.*$/', '', $values['imap_username'])).'+"') :
+            array()) ?>
 
     <?= $this->form->label(t("Kanboard's XML RPC URL"), 'imap_application_url') ?>
     <?= $this->form->text('imap_application_url', $values) ?>
 
-    <?= $this->form->label(t('User ID which creates tasks'), 'imap_guest_user_id') ?>
-    <?= $this->form->text('imap_guest_user_id', $values) ?>
+	<?= $this->form->label(t('User ID which creates tasks'), 'imap_guest_user_id') ?>
+	<?= $this->form->text('imap_guest_user_id', $values) ?>
 
-    <?= $this->form->label(t('Default task priority'), 'imap_default_priority') ?>
-    <?= $this->form->text('imap_default_priority', $values) ?>
+    <?= $this->form->label(t('Default Task Priority'), 'imap_default_priority') ?>
+    <?= $this->form->text('imap_default_priority', $values, array(), array('placeholder="0"')) ?>
 
-    <?= $this->form->label(t('Email automatic reply (can reference $task_id)'), 'imap_body_message') ?>
+	<?= $this->form->label(t('Generic Note Added to Task Description'), 'imap_task_description_message') ?>
+	<?= $this->form->text('imap_task_description_message', $values) ?>
+
+    <?= $this->form->label(t('Enable Automatic Email Replies'), 'imap_automatic_replies')  ?>
+	<?= $this->form->select('imap_automatic_replies', array(0 => 'No', 1 => 'Yes'), $values) ?>
+
+    <?= $this->form->label(t('Automatic Reply Body (can reference $task_id)'), 'imap_body_message') ?>
     <?= $this->form->text('imap_body_message', $values) ?>
-
-    <?= $this->form->label(t('Generic note added to task description'), 'imap_task_description_message') ?>
-    <?= $this->form->text('imap_task_description_message', $values) ?>
 
     <div class="form-actions">
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue">

--- a/Template/integration.php
+++ b/Template/integration.php
@@ -1,13 +1,14 @@
 <h3><img src="<?= $this->url->dir() ?>plugins/Imap/imap-icon.png"/>&nbsp;Imap</h3>
 <div class="listing">
 
+    <h3>IMAP Configuration</h3>
     <?= $this->form->label(t('IMAP Server'), 'imap_server') ?>
     <?= $this->form->text('imap_server', $values) ?>
 
     <?= $this->form->label(t('IMAP Server Port'), 'imap_server_port') ?>
     <?= $this->form->text('imap_server_port', $values) ?>
 
-    <?= $this->form->label(t('IMAP Server Requires SSL'), 'imap_server_requires_ssl') ?>
+    <?= $this->form->label(t('IMAP Server Requires SSL (0/1)'), 'imap_server_requires_ssl') ?>
     <?= $this->form->text('imap_server_requires_ssl', $values) ?>
 
     <?= $this->form->label(t('IMAP Username'), 'imap_username') ?>
@@ -16,22 +17,22 @@
     <?= $this->form->label(t('IMAP Password'), 'imap_password') ?>
     <?= $this->form->password('imap_password', $values) ?>
 
-    <?= $this->form->label(t('Mail prefix'), 'imap_mail_prefix') ?>
+    <?= $this->form->label(t("Mail prefix (Default: Add a '+' to your username)"), 'imap_mail_prefix') ?>
     <?= $this->form->text('imap_mail_prefix', $values) ?>
 
-    <?= $this->form->label(t('Application URL or Localhost Application URL'), 'imap_application_url') ?>
+    <?= $this->form->label(t("Kanboard's XML RPC URL"), 'imap_application_url') ?>
     <?= $this->form->text('imap_application_url', $values) ?>
 
-    <?= $this->form->label(t('Guest User ID'), 'imap_guest_user_id') ?>
+    <?= $this->form->label(t('User ID which creates tasks'), 'imap_guest_user_id') ?>
     <?= $this->form->text('imap_guest_user_id', $values) ?>
 
-    <?= $this->form->label(t('Default priority'), 'imap_default_priority') ?>
+    <?= $this->form->label(t('Default task priority'), 'imap_default_priority') ?>
     <?= $this->form->text('imap_default_priority', $values) ?>
 
-    <?= $this->form->label(t('Mail body message'), 'imap_body_message') ?>
+    <?= $this->form->label(t('Email automatic reply (can reference $task_id)'), 'imap_body_message') ?>
     <?= $this->form->text('imap_body_message', $values) ?>
 
-    <?= $this->form->label(t('Task description message'), 'imap_task_description_message') ?>
+    <?= $this->form->label(t('Generic note added to task description'), 'imap_task_description_message') ?>
     <?= $this->form->text('imap_task_description_message', $values) ?>
 
     <div class="form-actions">

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "fguillot/json-rpc": "1.2.3",
-	  "tedivm/fetch": "0.7.*"
+	  "tedivm/fetch": "0.7.*",
+      "ext-sqlite3": "*"
     }
 }

--- a/cron.php
+++ b/cron.php
@@ -13,19 +13,42 @@ $toaddress = "";
 $ccaddress = "";
 $comment['content'] = "";
 $task['description'] = "";
+$argv_db = $argv[1];
+$debug = ($argv_db == '--debug' || $argv_db == '-d');
 
-if (isset($argv[1]) && file_exists($argv[1])) {
+if ($debug) {
+    echo "Debug mode enabled.\n";
+    $argv_db = $argv[2];
+}
+
+if (isset($argv_db) && file_exists($argv_db)) {
     // Database to connect to and default settings.
-	$database = $argv[1];
+	$database = $argv_db;
 	$imap_server_port = 0;
 	$imap_server_port_default = 993;
 	$mail_prefix = null;
+	$imap_automatic_replies = 0;
+	$imap_enabled = 0;
+	$default_priority = 0;
 
 	// Load settings.
-	$db = new SQLite3($database);
-	$results = $db->query('SELECT option,value from settings where option IN ("imap_body_message","imap_default_priority","imap_server","imap_username","imap_password","imap_server_port","imap_server_requires_ssl","imap_mail_prefix","api_token","imap_application_url","imap_guest_user_id","imap_task_description_message")');
+    if ($debug) {
+        echo "Opening ".$database.".\n";
+    }
+	$db = new SQLite3($database, SQLITE3_OPEN_READONLY);
+	$results = $db->query(
+	        'SELECT option, value 
+                    FROM settings 
+                    WHERE option IN ("imap_body_message", "imap_default_priority", "imap_server", "imap_username",
+                                     "imap_password", "imap_server_port", "imap_server_requires_ssl",
+                                     "imap_mail_prefix", "api_token", "imap_application_url", "imap_guest_user_id",
+                                     "imap_task_description_message", "imap_enabled", "imap_automatic_replies")');
+
 	while ($row = $results->fetchArray()) {
 		switch ($row['option']) {
+            case "imap_enabled":
+                $imap_enabled = intval($row['value']);
+                break;
 			case "imap_server":
 				$imap_server = $row['value'];
 				break;
@@ -58,8 +81,13 @@ if (isset($argv[1]) && file_exists($argv[1])) {
 				$imap_guest_user_id = $row['value'];
 				break;
 			case "imap_default_priority":
-				$default_priority = $row['value'];
+			    if ($row['value']) {
+                    $default_priority = $row['value'];
+                }
 				break;
+            case "imap_automatic_replies":
+                $imap_automatic_replies = intval($row['value']);
+                break;
 			case "imap_body_message":
 				$body_message_configured = $row['value'];
 				break;
@@ -70,12 +98,29 @@ if (isset($argv[1]) && file_exists($argv[1])) {
 		}
 	}
 
+	// There is no reason to hold the database connection open.
+	$db->close();
+	if ($debug) {
+	    echo "Database closed.\n";
+    }
+
+	// Turn off the rest of our processing without removing the plugin.
+	if (!$imap_enabled) {
+	    if ($debug) {
+	        echo "Plugin disabled. Exiting.";
+        }
+	    exit;
+    }
+
 	// Default to the RFC 5233 Subaddress Extension format.
 	if (!$mail_prefix) {
 	    $mail_prefix = preg_replace('/@.*$/', '', $imap_username).'+';
     }
 
 	// Connect to Kanboard via XmlRPC.
+    if ($debug) {
+        echo "Using JSONRPC endpoint of: ".$jsonrpc_url."\n";
+    }
 	$client = new JsonRPC\Client($jsonrpc_url);
 	$client->authentication($jsonrpc_auth_name, $jsonrpc_auth_token);
 	$projects_tmp = $client->execute('getAllProjects');
@@ -87,6 +132,9 @@ if (isset($argv[1]) && file_exists($argv[1])) {
 	}
 
 	// Connect to the IMAP server.
+    if ($debug) {
+        echo 'Connecting to IMAP server '.$imap_server.':'.$imap_server_port.' (SSL'.($imap_server_requires_ssl ? '' : ' not ')." required).\n";
+    }
 	$imap_server_port = $imap_server_port ? $imap_server_port : $imap_server_port_default;
 	$server = new Server($imap_server, $imap_server_port);
 	$server->setAuthentication($imap_username, $imap_password);
@@ -105,6 +153,10 @@ if (isset($argv[1]) && file_exists($argv[1])) {
             " SSL as $imap_username: ". $e->getMessage());
     }
 
+	if ($debug) {
+	    echo 'Found '.count($messages)." new message(s).\n";
+    }
+
 	// Loop through the unread email messages.
     foreach ($messages as $message) {
         $body_text = $message->getMessageBody();
@@ -115,7 +167,9 @@ if (isset($argv[1]) && file_exists($argv[1])) {
         $header = $message->getHeaders();
         $task_id = null;
 
-        // throw new Exception($message->getSubject());
+        if ($debug) {
+            echo 'New Message from '.$from['address'].': '.$message->getSubject();
+        }
 
         // Parse the important email addresses.
         if (!empty($cc)) {
@@ -124,6 +178,7 @@ if (isset($argv[1]) && file_exists($argv[1])) {
                     $ccaddress .= $ccfor['address'] . ",";
                 }
             }
+            // Remove the last comma.
             $ccaddress = substr_replace($ccaddress, "", -1);
         }
         foreach ($to as $tofor) {
@@ -146,7 +201,7 @@ if (isset($argv[1]) && file_exists($argv[1])) {
         $headers .= 'From: '.$imap_username. "\r\n" .
                 'Reply-To: <'.$imap_username.'>'. "\r\n" .
                 'To: '.$from['address']."\r\n".
-                'CC: '.$toaddress.','.$ccaddress."\r\n". // TODO: Will CC'ing ourselves create a loop?
+                'CC: '.$toaddress.','.$ccaddress."\r\n".
                 'In-Reply-To: <'.$header->message_id.'>'. "\r\n" .
                 'References: <'.$header->message_id.'>'. "\r\n" .
                 'X-Mailer: PHP/' . phpversion(). "\r\n";
@@ -171,37 +226,58 @@ if (isset($argv[1]) && file_exists($argv[1])) {
 
         // If a valid Task ID was specified, add a comment to it.
         if ($task_id && $client->getTask($task_id)) {
+            if ($debug) {
+                echo 'Found Task ID: '.$task_id.". Adding comment.\n";
+            }
             $comment['task_id'] = $task_id;
             $comment['content'] .= $body_text;
             $response = $client->createComment($comment);
 
-            $subject = "Re: Added your comment on task ".$task_id;
-            $body_message = 'I added your comment on '.$task_id.'.'.$body_message;
-            $headers .= 'Subject: '.$subject;
-            if (!mail($toaddress, $subject, $body_message, $headers)) {
-                throw new Exception('Failed to send comment confirmation.');
+            if ($imap_automatic_replies) {
+                if ($debug) {
+                    echo "Replying with confirmation.\n";
+                }
+                $subject = "Re: Added your comment on task " . $task_id;
+                $body_message = 'I added your comment on ' . $task_id . '.' . $body_message;
+                $headers .= 'Subject: ' . $subject;
+                if (!mail($toaddress, $subject, $body_message, $headers)) {
+                    throw new Exception('Failed to send comment confirmation.');
+                }
             }
         } else {
             // Try to detect the project that we want.
             if (strpos($to[0]['address'], $mail_prefix) !== false) {
                 $project_identifier = str_replace($mail_prefix, '', $to[0]['address']);
                 $project_identifier = strstr($project_identifier, '@', true);
+                if ($debug) {
+                    echo 'Found project identifier in subject line: '.$project_identifier.".\n";
+                }
                 if (isset($projects[strtoupper($project_identifier)])) {
                     $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
+                } else if ($debug) {
+                    echo "Project identifier does not seem to exist in the database.\n";
                 }
             } else {
                 if (preg_match('~<(.*?)>~', $message->getSubject(), $output)) {
                     $project_identifier = $output[1];
+                    if ($debug) {
+                        echo 'Found project identifier in subject line: '.$project_identifier.".\n";
+                    }
                     if (isset($projects[strtoupper($project_identifier)])) {
                         $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
+                    } else if ($debug) {
+                        echo "Project identifier does not seem to exist in the database.\n";
                     }
-                } else {
+                } else if ($imap_automatic_replies) {
                     // We failed to detect which project the user wanted. Send a rejection notice.
+                    if ($debug) {
+                        echo "Unable to determine project identifier. Replying with failure message.\n";
+                    }
                     $subject = "Re: ERROR: ".$message->getSubject();
                     $body_message = 'Sorry, I was not able to determine which project this was for.'.$body_message;
                     $headers .= 'Subject: '.$subject;
                     if (!mail($toaddress, $subject, $body_message, $headers)) {
-                        throw new Exception('Failed to send project lookup error message.');
+                        throw new Exception('Failed to send failure message.');
                     }
                     continue;
                 }
@@ -217,15 +293,20 @@ if (isset($argv[1]) && file_exists($argv[1])) {
             $task_id = $client->createTask($task);
 
             // Confirm to the sender that we created a new task.
-            $subject = "Re: ".$message->getSubject()." TaskID#[".$task_id."]";
-            $body_message = str_replace('$task_id', $task_id, $body_message_configured).$body_message;
-            $headers .= 'Subject: '.$subject;
-            if (!mail($toaddress, $subject, $body_message, $headers)) {
-                throw new Exception('Failed to send task creation confirmation.');
+            if ($imap_automatic_replies) {
+                if ($debug) {
+                    echo "Replying with confirmation.\n";
+                }
+
+                $subject = "Re: " . $message->getSubject() . " TaskID#[" . $task_id . "]";
+                $body_message = str_replace('$task_id', $task_id, $body_message_configured) . $body_message;
+                $headers .= 'Subject: ' . $subject;
+                if (!mail($toaddress, $subject, $body_message, $headers)) {
+                    throw new Exception('Failed to send task creation confirmation.');
+                }
             }
         }
     }
 } else {
-	throw new Exception("You must specify the database path");
+	throw new Exception("You must specify the database path.");
 }
-?>

--- a/cron.php
+++ b/cron.php
@@ -9,13 +9,19 @@ $projects = array();
 $users = array();
 $tasks = array();
 $jsonrpc_auth_name = "jsonrpc";
-$toaddress="";
-$ccaddress="";
-$comment['content']="";
-$task['description']="";
+$toaddress = "";
+$ccaddress = "";
+$comment['content'] = "";
+$task['description'] = "";
 
-if ( isset($argv[1]) ) {
-	$database=$argv[1];
+if (isset($argv[1]) && file_exists($argv[1])) {
+    // Database to connect to and default settings.
+	$database = $argv[1];
+	$imap_server_port = 0;
+	$imap_server_port_default = 993;
+	$mail_prefix = null;
+
+	// Load settings.
 	$db = new SQLite3($database);
 	$results = $db->query('SELECT option,value from settings where option IN ("imap_body_message","imap_default_priority","imap_server","imap_username","imap_password","imap_server_port","imap_server_requires_ssl","imap_mail_prefix","api_token","imap_application_url","imap_guest_user_id","imap_task_description_message")');
 	while ($row = $results->fetchArray()) {
@@ -30,129 +36,196 @@ if ( isset($argv[1]) ) {
 				$imap_password = $row['value'];
 				break;
 			case "imap_server_port":
-				$imap_server_port = $row['value'];
+				$imap_server_port = intval($row['value']);
 				break;
 			case "imap_server_requires_ssl":
 				$imap_server_requires_ssl = $row['value'];
+				$imap_server_port_default = $row['value'] ? 993 : 143;
 				break;
 			case "imap_mail_prefix":
-				$mail_prefix = $row['value'];
+			    if (!empty($row['value'])) {
+                    $mail_prefix = $row['value'];
+                }
 				break;
 			case "api_token":
+			    // Detect the JSON RPC token from the database.
 				$jsonrpc_auth_token = $row['value'];
 				break;
 			case "imap_application_url":
-				$jsonrpc_url= $row['value'];
+				$jsonrpc_url = $row['value'];
 				break;
 			case "imap_guest_user_id":
-				$imap_guest_user_id= $row['value'];
+				$imap_guest_user_id = $row['value'];
 				break;
 			case "imap_default_priority":
-				$default_priority= $row['value'];
+				$default_priority = $row['value'];
 				break;
 			case "imap_body_message":
-				$body_message= $row['value'];
+				$body_message_configured = $row['value'];
 				break;
 			case "imap_task_description_message":
-				$task_description_message= $row['value'];
+				$task_description_message = $row['value'];
 				break;
-			
+
 		}
 	}
+
+	// Default to the RFC 5233 Subaddress Extension format.
+	if (!$mail_prefix) {
+	    $mail_prefix = preg_replace('/@.*$/', '', $imap_username).'+';
+    }
+
+	// Connect to Kanboard via XmlRPC.
 	$client = new JsonRPC\Client($jsonrpc_url);
 	$client->authentication($jsonrpc_auth_name, $jsonrpc_auth_token);
 	$projects_tmp = $client->execute('getAllProjects');
-	$users_tmp= $client->execute('getAllUsers');
+	$users_tmp = $client->execute('getAllUsers');
 	foreach ($projects_tmp as $proj) {
-		if ($proj['identifier']){
+		if ($proj['identifier']) {
 			$projects[$proj['identifier']]['id'] = $proj['id'];
 		}
 	}
-	$server = new Server($imap_server,993);
+
+	// Connect to the IMAP server.
+	$imap_server_port = $imap_server_port ? $imap_server_port : $imap_server_port_default;
+	$server = new Server($imap_server, $imap_server_port);
 	$server->setAuthentication($imap_username, $imap_password);
-	$messages = $server->search('UNSEEN');
-		foreach ($messages as $message) {
-			$body_text=$message->getMessageBody();
-			$body_html=$message->getMessageBody($html=true);
-                        preg_match('~TaskID#\[(.*?)\]~', $message->getSubject(), $output);
-			$task_id = $output[1];
-			$to = $message->getAddresses("to"); 
-			$cc = $message->getAddresses("cc");
-			$from = $message->getAddresses("from");
-			$header=$message->getHeaders();
-			foreach ($cc as $ccfor) {
-				if ( "$imap_username" != $ccfor['address'] ) {
-					$ccaddress .= $ccfor['address'].",";
-				}
-			}
-			$ccaddress=substr_replace($ccaddress, "", -1);
-			foreach ($to as $tofor) {
-				if ( "$imap_username" != $tofor['address'] ) {
-					$toaddress .= $tofor['address'].",";
-				}
-			}
-			$toaddress=substr_replace($toaddress, "", -1);
-			$comment['user_id'] = $imap_guest_user_id; 
-			$task['creator_id'] = $imap_guest_user_id; 
-                        foreach ($users_tmp as $user) {
-                        	if ( strtolower($user['email']) == strtolower($from['address']) ){
-                                	$comment['user_id'] = $user['id'];
-					$task['creator_id'] = $user['id'];
-                                }
-                       }
-                       if ( $comment['user_id']==$imap_guest_user_id && $imap_guest_user_id != "" ) {
-                                        $comment['content'].="From: ".strtolower($from['address'])."\r\n";
-                                        $task['description'].="From: ".strtolower($from['address'])."\r\n";
-                       }
 
-			if ( $client->getTask($task_id) ) {
-				$comment['task_id']=$task_id;
-				$comment['content'].=$body_text;
-				$response=$client->createComment($comment);	
-			}
-			else {
-				if (strpos($to[0]['address'],$mail_prefix) !== false){
-					$project_identifier = str_replace($mail_prefix,'',$to[0]['address']);
-					$project_identifier = strstr($project_identifier, '@', true);
-					if (isset($projects[strtoupper($project_identifier)])) {
-					        $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
-					}
-				}
-				else {
-					        preg_match('~<(.*?)>~', $message->getSubject(), $output);
-                                               	$project_identifier = $output[1];
-	                                        if (isset($projects[strtoupper($project_identifier)])) {
-	                                                $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
-					}
-				}
-                                $task['title'] = str_replace("<$project_identifier>",'',$message->getSubject());
-				$task['description'] .= "\r\n".$task_description_message."\r\n";
-				$task['description'] .= $body_text;
-                                $task['priority'] = $default_priority;
-                                $task_id = $client->createTask($task);
-
-                                $subject = "Re: ".$message->getSubject()." TaskID#[".$task_id."]";
-			        $body_message=str_replace('$task_id',$task_id,$body_message);
-  			        $body_message.="<br><br>----- Mensaje Original -----<br><br>";
-				$body_message.="From: ".$from['address']."\n";
-				$body_message.="To: ".$toaddress."\n";
-				$body_message.="Cc: ".$ccaddress."\n";
-			        $body_message.="$body_html";
-                                $headers = 'MIME-Version: 1.0' . "\r\n";
-                                $headers .= 'Content-type: text/html; charset=UTF-8' . "\r\n";
-                                $headers .= 'From: '.$imap_username. "\r\n" .
-                                'Reply-To:  <'.$imap_username.'>'. "\r\n" .
-                                'Subject: '.$subject."\r\n".
-                                'To: '.$from['address']."\r\n".
-                                'CC: '.$toaddress.','.$ccaddress."\r\n".
-                                'In-Reply-To: <'.$header->message_id.'>'. "\r\n" .
-                                'References: <'.$header->message_id.'>'. "\r\n" .
-                                'X-Mailer: PHP/' . phpversion();
-                                mail($toaddress,$subject,$body_message,$headers);			}
-		}
+	// Override Server initialization based on the user's configuration.
+	if ($imap_server_requires_ssl) {
+		$server->setFlag('ssl');
+	} else {
+		$server->setFlag('novalidate-cert');
 	}
-else
-{
-	echo "You must specify the database path\n";
+
+	try {
+        $messages = $server->search('UNSEEN');
+    } catch (Exception $e) {
+	    throw new Exception("Error connecting to IMAP server $imap_server:$imap_server_port with".($imap_server_requires_ssl ? '' : 'out').
+            " SSL as $imap_username: ". $e->getMessage());
+    }
+
+	// Loop through the unread email messages.
+    foreach ($messages as $message) {
+        $body_text = $message->getMessageBody();
+        $body_html = $message->getMessageBody($html = true);
+        $to = $message->getAddresses("to");
+        $cc = $message->getAddresses("cc");
+        $from = $message->getAddresses("from");
+        $header = $message->getHeaders();
+        $task_id = null;
+
+        // throw new Exception($message->getSubject());
+
+        // Parse the important email addresses.
+        if (!empty($cc)) {
+            foreach ($cc as $ccfor) {
+                if ($imap_username != $ccfor['address']) {
+                    $ccaddress .= $ccfor['address'] . ",";
+                }
+            }
+            $ccaddress = substr_replace($ccaddress, "", -1);
+        }
+        foreach ($to as $tofor) {
+            if ($imap_username != $tofor['address']) {
+                $toaddress .= $tofor['address'].",";
+            }
+        }
+        $toaddress = substr_replace($toaddress, "", -1);
+
+        // Prepare to email the user back.
+        $body_message = "<br><br>----- Original Message -----<br><br>";
+        $body_message .= "From: ".$from['address']."\n";
+        $body_message .= "To: ".$toaddress."\n";
+        if ($ccaddress) {
+            $body_message .= "Cc: " . $ccaddress . "\n";
+        }
+        $body_message .= $body_html;
+        $headers = 'MIME-Version: 1.0' . "\r\n";
+        $headers .= 'Content-type: text/html; charset=UTF-8' . "\r\n";
+        $headers .= 'From: '.$imap_username. "\r\n" .
+                'Reply-To: <'.$imap_username.'>'. "\r\n" .
+                'To: '.$from['address']."\r\n".
+                'CC: '.$toaddress.','.$ccaddress."\r\n". // TODO: Will CC'ing ourselves create a loop?
+                'In-Reply-To: <'.$header->message_id.'>'. "\r\n" .
+                'References: <'.$header->message_id.'>'. "\r\n" .
+                'X-Mailer: PHP/' . phpversion(). "\r\n";
+
+        // Try to detect the task ID from the subject line.
+        if (preg_match('~TaskID#\[(.*?)\]~', $message->getSubject(), $output)) {
+            $task_id = $output[1];
+        }
+
+        $comment['user_id'] = $imap_guest_user_id;
+        $task['creator_id'] = $imap_guest_user_id;
+        foreach ($users_tmp as $user) {
+            if (strtolower($user['email']) == strtolower($from['address'])) {
+                $comment['user_id'] = $user['id'];
+                $task['creator_id'] = $user['id'];
+            }
+        }
+        if ($comment['user_id'] == $imap_guest_user_id && $imap_guest_user_id != "") {
+            $comment['content'] .= "From: ".strtolower($from['address'])."\r\n";
+            $task['description'] .= "From: ".strtolower($from['address'])."\r\n";
+        }
+
+        // If a valid Task ID was specified, add a comment to it.
+        if ($task_id && $client->getTask($task_id)) {
+            $comment['task_id'] = $task_id;
+            $comment['content'] .= $body_text;
+            $response = $client->createComment($comment);
+
+            $subject = "Re: Added your comment on task ".$task_id;
+            $body_message = 'I added your comment on '.$task_id.'.'.$body_message;
+            $headers .= 'Subject: '.$subject;
+            if (!mail($toaddress, $subject, $body_message, $headers)) {
+                throw new Exception('Failed to send comment confirmation.');
+            }
+        } else {
+            // Try to detect the project that we want.
+            if (strpos($to[0]['address'], $mail_prefix) !== false) {
+                $project_identifier = str_replace($mail_prefix, '', $to[0]['address']);
+                $project_identifier = strstr($project_identifier, '@', true);
+                if (isset($projects[strtoupper($project_identifier)])) {
+                    $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
+                }
+            } else {
+                if (preg_match('~<(.*?)>~', $message->getSubject(), $output)) {
+                    $project_identifier = $output[1];
+                    if (isset($projects[strtoupper($project_identifier)])) {
+                        $task['project_id'] = $projects[strtoupper($project_identifier)]['id'];
+                    }
+                } else {
+                    // We failed to detect which project the user wanted. Send a rejection notice.
+                    $subject = "Re: ERROR: ".$message->getSubject();
+                    $body_message = 'Sorry, I was not able to determine which project this was for.'.$body_message;
+                    $headers .= 'Subject: '.$subject;
+                    if (!mail($toaddress, $subject, $body_message, $headers)) {
+                        throw new Exception('Failed to send project lookup error message.');
+                    }
+                    continue;
+                }
+            }
+
+            // Create a new task.
+            $task['title'] = str_replace("<$project_identifier>", '', $message->getSubject());
+            if (!empty($task_description_message)) {
+                $task['description'] .= "\r\n" . $task_description_message;
+            }
+            $task['description'] .= "\r\n".$body_text;
+            $task['priority'] = $default_priority;
+            $task_id = $client->createTask($task);
+
+            // Confirm to the sender that we created a new task.
+            $subject = "Re: ".$message->getSubject()." TaskID#[".$task_id."]";
+            $body_message = str_replace('$task_id', $task_id, $body_message_configured).$body_message;
+            $headers .= 'Subject: '.$subject;
+            if (!mail($toaddress, $subject, $body_message, $headers)) {
+                throw new Exception('Failed to send task creation confirmation.');
+            }
+        }
+    }
+} else {
+	throw new Exception("You must specify the database path");
 }
 ?>


### PR DESCRIPTION
I started to clean this up so that the configuration was easier to understand and the updates got away from me. Let me know if you would prefer that anything be rolled back. Overall, the functionality should be the same.

* Clarified the names of the settings field labels. On/Off flags became dropdown select fields.
* Improved the handling of default values in the code.
* Added On/Off settings for the plugin and email replies.
* Added Debug flag for the cron job (-d, --debug).
* Clarified behavior described in the README file. Documented the task comment capability.
* Added notation for composer that PHP's ext-sqlite3 capability is required. Probably moot if the user is running Kanboard already.
* Only open the database in read-only mode, and close the connection before we ask Kanboard to add tasks or comments.
* Bumped plugin version number due to the UI changes.